### PR TITLE
Shaoqz/fix accre get status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/*
+*.pyc

--- a/Class_Conf.py
+++ b/Class_Conf.py
@@ -25,7 +25,7 @@ class Config:
     #
     n_cores = 24
     # -----------------------------
-    # Per core memory in MB
+    # Per core memory in MB (required by Gaussian input by now)
     #
     max_core = 2000
     # -----------------------------

--- a/Class_Conf.py
+++ b/Class_Conf.py
@@ -8,9 +8,9 @@ Config --- Amber
         |- Multiwfn
 -------------------------------------------------------------------------------------
 '''
+import os
 from time import strftime, localtime
 import re
-from helper import mkdir, line_feed
 
 
 class Config:
@@ -18,6 +18,7 @@ class Config:
     since the workflow is not settled, workflow related value should not be the global var here.
     It is better to have default settings here.
     '''
+    line_feed = '\n'
     # >>>>>> Resource <<<<<<
 	# -----------------------------
     # Cores available (used in MD(Amber) and QM(Gaussian) calculations)
@@ -334,7 +335,10 @@ class Config:
                 build MMPBSA.in in out_path
                 '''
                 if out_path == '':
-                    mkdir('./tmp')
+                    if os.path.exists('./tmp'):
+                        pass
+                    else:
+                        os.makedirs('./tmp')
                     out_path = './tmp/MMPBSA.in'
 
                 # make lines

--- a/Class_PDB.py
+++ b/Class_PDB.py
@@ -1385,8 +1385,8 @@ class PDB():
         try:
             run('tleap -s -f '+leap_path+' > '+leap_path[:-2]+'out', check=True,  text=True, shell=True, capture_output=True)
         except SubprocessError as e:
-            print(f'stderr: {e.stderr.strip()}')
-            print(f'stdout: {e.stdout.strip()}')
+            print(f'stderr: {str(e.stderr).strip()}')
+            print(f'stdout: {str(e.stdout).strip()}')
             raise e
 
         return self.prmtop_path, self.inpcrd_path

--- a/Class_PDB.py
+++ b/Class_PDB.py
@@ -161,16 +161,18 @@ class PDB():
                     print('PDB.get_stru: WARNING: self.stru has a different name')
                     print('     -self.name: '+self.name)
                     print('     -self.stru.name: '+self.stru.name)
-                    print('Getting new stru')
         else:
             get_flag = 1
 
         if get_flag or renew:
+            if Config.debug >= 1:
+                print('PDB.get_stru: Getting new stru')
             if self.path is not None:
                 self.stru = Structure.fromPDB(self.path, input_name=input_name, ligand_list=ligand_list)
             else:
                 self.stru = Structure.fromPDB(self.file_str, input_type='file_str', input_name=input_name, ligand_list=ligand_list)
-
+        elif Config.debug >= 1:
+            print('PDB.get_stru: Not getting new stru - have existing self.stru with the same name and renew == 0')
 
     def _get_file_str(self):
         '''

--- a/Class_PDB.py
+++ b/Class_PDB.py
@@ -1375,8 +1375,8 @@ class PDB():
         try:
             run('tleap -s -f '+leap_path+' > '+leap_path[:-2]+'out', check=True,  text=True, shell=True, capture_output=True)
         except SubprocessError as e:
-            print(f'stderr: {e.stderr}')
-            print(f'stdout: {e.stdout}')
+            print(f'stderr: {e.stderr.strip()}')
+            print(f'stdout: {e.stdout.strip()}')
             raise e
 
         return self.prmtop_path, self.inpcrd_path

--- a/Class_PDB.py
+++ b/Class_PDB.py
@@ -1112,8 +1112,8 @@ class PDB():
                 if isinstance(res_setting, dict):
                     cpu_cores = res_setting['node_cores']
                 else: # directly use argument -> support non-dict res_setting input e.g.: str
-                    if cpu_cores == None: # TODO may be require the cluster interface to resolve different res_setting type in the future.
-                        raise TypeError('ERROR: Requires cpu_cores input if using CPU and provide res_setting not as a dict')
+                    if cpu_cores == None:
+                        raise TypeError('ERROR: Requires cpu_cores input for configuring sander if using CPU and provide res_setting not as a dict')
         elif cpu_cores != None:
             raise TypeError('ERROR: cpu_cores should be None if not submit to cluster.')
         # express engine
@@ -1524,8 +1524,8 @@ class PDB():
                 if isinstance(res_setting, dict):
                     cpu_cores = res_setting['node_cores']
                 else: # support non-dict res_setting input e.g.: str
-                    if cpu_cores == None: # TODO may be require the cluster interface to resolve different res_setting type in the future.
-                        raise TypeError('ERROR: Requires cpu_cores input if using CPU and provide res_setting not as a dict')
+                    if cpu_cores == None:
+                        raise TypeError('ERROR: Requires cpu_cores input for configuring sander if using CPU and provide res_setting not as a dict')
 
             if core_type == 'GPU' and equi_cpu:
                 # get env res for equi
@@ -1534,8 +1534,8 @@ class PDB():
                 if isinstance(res_setting_equi_cpu, dict):
                     equi_cpu_cores = res_setting_equi_cpu['node_cores']
                 else: # support non-dict res_setting input e.g.: str
-                    if equi_cpu_cores == None: # TODO may be require the cluster interface to resolve different res_setting type in the future.
-                        raise TypeError('ERROR: Requires equi_cpu_cores input if using CPU and provide equi_res_setting not as a dict')
+                    if equi_cpu_cores == None:
+                        raise TypeError('ERROR: Requires equi_cpu_cores input for configuring sander if using CPU and provide equi_res_setting not as a dict')
         else:
             if cpu_cores != None or equi_cpu_cores != None:
                 raise TypeError('ERROR: cpu_cores or equi_cpu_cores should be None if not submit to cluster.')        
@@ -2362,7 +2362,7 @@ class PDB():
         cluster: ClusterInterface = None,
         job_array_size: int = 0,
         period: int = 600,
-        res_setting: Union[dict, None] = None,
+        res_setting: Union[dict, str, None] = None,
         cpu_cores: Union[int, str, None] = None,
         cpu_mem: Union[int, str, None] = None,
         cluster_debug: bool = 0
@@ -2453,9 +2453,10 @@ class PDB():
             if QM in ['g16','g09']:
                 if isinstance(res_setting, dict):
                     cpu_cores = res_setting['node_cores']
-                    cpu_mem = int(float(res_setting['mem_per_core'].rstrip('GB')) * 1024)
+                    cpu_mem = res_setting['mem_per_core']
                 elif cpu_cores is None or cpu_mem is None:
-                    raise TypeError('ERROR: Requires cpu_cores and cpu_mem input if using CPU and provide res_setting not as a dict')
+                    raise TypeError('ERROR: Requires cpu_cores and cpu_mem input for configuring Gaussian input file if using CPU and provide res_setting not as a dict')
+                cpu_mem = int(float(cpu_mem.rstrip('GB')) * 1024) # convert to number in MB
         else:
             cpu_cores = Config.n_cores
             cpu_mem = Config.max_core

--- a/Class_PDB.py
+++ b/Class_PDB.py
@@ -1018,7 +1018,7 @@ class PDB():
         Y : Resi_list
         '''
         pattern = r'([A-Z])([A-Z])?([0-9]+)([A-Z])'
-        if Flag is 'WT':
+        if Flag == 'WT':
             return ('WT', 'WT', 'WT', 'WT')
         F_match = re.match(pattern, Flag)
         if F_match is None:

--- a/Class_PDB.py
+++ b/Class_PDB.py
@@ -1507,6 +1507,7 @@ class PDB():
             core_type = engine.split('_')[-1]
             res_setting, env_settings = type(self)._prepare_cluster_job_pdbmd(cluster, core_type, res_setting)
             if core_type == 'CPU':
+                # TODO(shaoqz) make this an object so that have common interface.
                 cpu_cores = res_setting['node_cores']
             if core_type == 'GPU' and equi_cpu:
                 # get env res for equi

--- a/core/clusters/accre.py
+++ b/core/clusters/accre.py
@@ -162,8 +162,8 @@ export GAUSS_SCRDIR=$TMPDIR/$SLURM_JOB_ID''',
             submit_cmd = run(cmd, timeout=120, check=True,  text=True, shell=True, capture_output=True)
         except SubprocessError as e: # capture both error and timeout
             print(f'Error running {cmd}: {repr(e)}')
-            print(f'stderr: {e.stderr}')
-            print(f'stdout: {e.stdout}')            
+            print(f'stderr: {e.stderr.strip()}')
+            print(f'stdout: {e.stdout.strip()}')            
             raise e
         finally:
             # TODO(shaoqz) timeout condition is hard to test

--- a/core/clusters/accre.py
+++ b/core/clusters/accre.py
@@ -162,8 +162,8 @@ export GAUSS_SCRDIR=$TMPDIR/$SLURM_JOB_ID''',
             submit_cmd = run(cmd, timeout=120, check=True,  text=True, shell=True, capture_output=True)
         except SubprocessError as e: # capture both error and timeout
             print(f'Error running {cmd}: {repr(e)}')
-            print(f'stderr: {e.stderr.strip()}')
-            print(f'stdout: {e.stdout.strip()}')            
+            print(f'stderr: {str(e.stderr).strip()}')
+            print(f'stdout: {str(e.stdout).strip()}')            
             raise e
         finally:
             # TODO(shaoqz) timeout condition is hard to test

--- a/helper.py
+++ b/helper.py
@@ -276,8 +276,8 @@ def run_cmd(cmd, try_time=1, wait_time=3, timeout=120) -> CompletedProcess:
         except SubprocessError as e:
             if Config.debug > 0:
                 print(f'Error running {cmd}: {repr(e)}')
-                print(f'    stderr: {e.stderr.strip()}')
-                print(f'    stdout: {e.stdout.strip()}')
+                print(f'    stderr: {str(e.stderr).strip()}')
+                print(f'    stdout: {str(e.stdout).strip()}')
                 print(f'trying again... (max_try: {try_time})')
         else: # untill there's no error
             if Config.debug > 0:

--- a/helper.py
+++ b/helper.py
@@ -3,10 +3,12 @@ Misc helper func and class
 '''
 from distutils.command.config import config
 import math
+from subprocess import CompletedProcess, SubprocessError, run
 import time
-from AmberMaps import Resi_list
 import os
 import numpy as np
+
+from Class_Conf import Config
 '''
 ====
 Tree
@@ -23,7 +25,7 @@ class Child():
 '''
 Text
 '''
-line_feed = '\n'
+line_feed = Config.line_feed
 
 '''
 file system
@@ -257,5 +259,34 @@ def chunked(iter_, size):
     '''
     return (iter_[position : position + size] for position in range(0, len(iter_), size))
 
-def get_localtime(time_stamp):
-    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time_stamp))
+def get_localtime(time_stamp=None):
+    if time_stamp is None:
+        return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    else:
+        return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time_stamp))
+
+def run_cmd(cmd, try_time=1, wait_time=3, timeout=120) -> CompletedProcess:
+    '''
+    try running the info cmd {try_time} times and wait {wait_time} between each run if subprocessexceptions are raised.
+    default be 1 run.
+    '''
+    for i in range(try_time):
+        try:
+            this_run = run(cmd, timeout=timeout, check=True,  text=True, shell=True, capture_output=True)
+        except SubprocessError as e:
+            if Config.debug > 0:
+                print(f'Error running {cmd}: {repr(e)}')
+                print(f'    stderr: {e.stderr.strip()}')
+                print(f'    stdout: {e.stdout.strip()}')
+                print(f'trying again... (max_try: {try_time})')
+        else: # untill there's no error
+            if Config.debug > 0:
+                if i > 0:
+                    print(f'finished {cmd} after {i+1} tries @{get_localtime()}')
+            return this_run
+        # wait before next try
+        time.sleep(wait_time)
+    # exceed the try time
+    if Config.debug > 0:
+        print(f'Failed running `{cmd}` after {try_time} tries @{get_localtime()}')
+    raise SubprocessError # TODO change to a costum error

--- a/test/core/test_job_manager.py
+++ b/test/core/test_job_manager.py
@@ -111,8 +111,7 @@ module load Gaussian/16.B.01
 mkdir $TMPDIR/$SLURM_JOB_ID
 export GAUSS_SCRDIR=$TMPDIR/$SLURM_JOB_ID
 
-g16 < TS-2-dp-opt.gjf > TS-2-dp-opt.out
-rm -r $TMPDIR/$SLURM_JOB_ID
+g16 < QM_test.gjf > QM_test.out
 trap 'rm -rf $TMPDIR/$SLURM_JOB_ID' EXIT'''
 
 sub_script_long_str = '''#!/bin/bash
@@ -279,14 +278,14 @@ def test_ClusterJob_wait_to_end_ACCRE():
     '''
     only run on accre
     '''
-    job = ClusterJob(clusters.accre.Accre(), sub_script_str=sub_script_long_str)
+    job = ClusterJob(clusters.accre.Accre(), sub_script_str=sub_script_str)
     # submit and record the file
     job.submit(sub_dir=test_sub_dir)
     test_file_paths.extend([job.job_cluster_log, job.sub_script_path])
     test_file_paths.append(f'{test_sub_dir}/submitted_job_ids.log')
 
     Config.debug = 2
-    job.wait_to_end(60)
+    job.wait_to_end(10)
     # TODO add some assert
 
 @pytest.mark.accre

--- a/test/test_Class_PDB.py
+++ b/test/test_Class_PDB.py
@@ -121,6 +121,30 @@ def test_PDB2FF_keep():
     assert len(pdb_obj.prepi_path) != 0
 
 @pytest.mark.md
+def test_pdbmd_without_job_manager_but_input_cpu_cores():
+    test_dir_md = 'test/testfile_Class_PDB/MD_test/'
+    # interface to PDBMD
+    pdb_obj = PDB(f'{test_dir_md}FAcD_RA124M_ff.pdb', wk_dir=test_dir_md)
+    pdb_obj.prmtop_path = f'{test_dir_md}FAcD_RA124M_ff.prmtop'
+    pdb_obj.inpcrd_path = f'{test_dir_md}FAcD_RA124M_ff.inpcrd'
+    # run MD
+    with pytest.raises(TypeError) as e:
+        pdb_obj.PDBMD(  engine='Amber_GPU', 
+                        equi_cpu=1, 
+                        if_cluster_job=0,
+                        equi_cpu_cores=10
+                         )
+        assert 'ERROR: cpu_cores or equi_cpu_cores should be None if not submit to cluster.' in str(e.value)
+    with pytest.raises(TypeError) as e:
+        pdb_obj.PDBMD(  engine='Amber_CPU',
+                        cpu_cores= 10,
+                        if_cluster_job=0,
+                        equi_cpu_cores=10
+                         )
+        assert 'ERROR: cpu_cores or equi_cpu_cores should be None if not submit to cluster.' in str(e.value)
+
+
+@pytest.mark.md
 @pytest.mark.accre
 def test_pdbmd_with_job_manager_capture_amber_err():
     test_dir_md = 'test/testfile_Class_PDB/MD_test/'

--- a/test/test_Class_PDB.py
+++ b/test/test_Class_PDB.py
@@ -261,6 +261,64 @@ def test_pdb2qmcluster_with_job_manager():
         assert os.path.getsize(out) != 0
 
 @pytest.mark.qm
+@pytest.mark.accre
+def test_pdb2qmcluster_with_job_manager_str_res_setting():
+    test_dir_qmcluster = 'test/testfile_Class_PDB/QMCluster_test/'
+    # interface of PDB2QMCluster
+    pdb_obj = PDB(f'{test_dir_qmcluster}FAcD_RA124M_ff.pdb', wk_dir=test_dir_qmcluster)
+    pdb_obj.prmtop_path = f'{test_dir_qmcluster}FAcD_RA124M_ff.prmtop'
+    pdb_obj.mdcrd = f'{test_dir_qmcluster}prod.mdcrd'
+    pdb_obj.prepi_path = {'FAH':f'{test_dir_qmcluster}../ligands/ligand_FAH.prepin'}
+    # arguments of PDB2QMCluster
+    atom_mask = ':108,298'
+    g_route = '# hf/6-31G(d) nosymm'
+    res_str = '''#!/bin/bash
+#SBATCH --partition=production
+#SBATCH --job-name=EnzyHTP-test-str
+#SBATCH --nodes=1
+#SBATCH --tasks-per-node=8
+#SBATCH --mem=30G
+#SBATCH --time=30:00
+#SBATCH --account=yang_lab_csb
+'''
+    with pytest.raises(TypeError) as e: # the case without nessessary information
+        pdb_obj.PDB2QMCluster(
+            atom_mask, 
+            g_route=g_route, 
+            if_cluster_job=1, 
+            cluster=accre.Accre(), 
+            job_array_size=20, 
+            period=30,
+            res_setting=res_str,
+            cluster_debug=1
+            )
+        assert 'ERROR: Requires cpu_cores and cpu_mem input for configuring Gaussian input file if using CPU and provide res_setting not as a dict' in str(e.value)
+    qm_outs = pdb_obj.PDB2QMCluster(
+                atom_mask, 
+                g_route=g_route, 
+                if_cluster_job=1, 
+                cluster=accre.Accre(), 
+                job_array_size=20, 
+                period=30,
+                res_setting=res_str,
+                cpu_cores=8,
+                cpu_mem='2GB',
+                cluster_debug=1
+                )
+    # track files
+    qm_jobs = pdb_obj.qm_cluster_jobs
+    qm_ins = list(map(lambda x: x.removesuffix('out')+'gjf',qm_outs))
+    test_file_paths.extend(qm_outs)
+    test_file_paths.extend(qm_ins)
+    test_file_paths.append('submitted_job_ids.log')
+    for job in qm_jobs:
+        test_file_paths.extend([job.sub_script_path, job.job_cluster_log])
+    # assert result
+    for out in qm_outs:
+        assert os.path.isfile(out)
+        assert os.path.getsize(out) != 0
+
+@pytest.mark.qm
 def test_make_single_g16_job_loop():
     '''
     test the loop section in RunQM

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -1,0 +1,12 @@
+from subprocess import SubprocessError
+import pytest
+import helper
+
+def test_run_cmd_fail_case():
+    cmd_fail = 'cat abc'
+    with pytest.raises(SubprocessError) as e:
+        helper.run_cmd(cmd_fail, try_time=3, wait_time=1)
+
+def test_run_cmd_no_retry():
+    cmd = 'squeue -u $USER'
+    assert len(helper.run_cmd(cmd).stdout) != 0

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -7,6 +7,7 @@ def test_run_cmd_fail_case():
     with pytest.raises(SubprocessError) as e:
         helper.run_cmd(cmd_fail, try_time=3, wait_time=1)
 
+@pytest.mark.accre
 def test_run_cmd_no_retry():
     cmd = 'squeue -u $USER'
     assert len(helper.run_cmd(cmd).stdout) != 0


### PR DESCRIPTION
ACCRE have some time-dependent problem that will make squeue or sacct timeout. 
This fix solves the problem by running those commands repetitively until there;s no exceptions from subprocess.run()
Current setting is retry up to 2880 tims per 30s to cover a day.