### PR TITLE
Bugfix: fix the problem in issue #126

### DIFF
--- a/enzy_htp/core/general.py
+++ b/enzy_htp/core/general.py
@@ -175,11 +175,11 @@ def get_copy_of_deleted_dict(orig_dict: Dict, del_key) -> Dict:
 # == context manager ==
 class HiddenPrints:
     """block or redirect stdout/stderr prints to 'redirect'
-    
+
     Example:
         with HiddenPrints(filename):
             print('this will go to filename')
-    
+
     Note:
         This function will also redirect all the influenced logging handlers"""
     def __init__(self, redirect=os.devnull):

--- a/enzy_htp/core/logger.py
+++ b/enzy_htp/core/logger.py
@@ -55,3 +55,4 @@ def init_logger(
 
 _LOGGER = init_logger("EnzyHTP", None, start=True)
 """Singleton logging object to log to throught enzy_htp."""
+_LOGGER.propagate = False # want to make sure EnzyHTP logger is not affected by root logger


### PR DESCRIPTION
The EnzyHTP logger is set to not refer to handlers in the root logger. As such it will not be influenced by the changes on the root logger in PDB2PQR