### PR TITLE
Chrisjurich/reduce pymol file io

### DIFF
--- a/enzy_htp/_interface/pymol_interface.py
+++ b/enzy_htp/_interface/pymol_interface.py
@@ -173,7 +173,7 @@ class PyMolInterface(BaseInterface):
         
         pymol_obj_name:str = self.general_cmd(session, [('get_unused_name',)])[0] 
         
-        self.general_cmd(session, [('read_pdb_str', pdb_str, pymol_obj_name)])
+        self.general_cmd(session, [('read_pdbstr', pdb_str, pymol_obj_name)])
 
 
         return (pymol_obj_name, session)

--- a/enzy_htp/_interface/pymol_interface.py
+++ b/enzy_htp/_interface/pymol_interface.py
@@ -159,29 +159,22 @@ class PyMolInterface(BaseInterface):
 
     # == intra-session modular functions == (requires a session and wont close it)
     def load_enzy_htp_stru(self, session: pymol2.PyMOL, stru: Structure) -> Tuple[str, pymol2.PyMOL]:
-        """convert enzy_htp.Structure into a pymol object in a
-        pymol2.PyMOL() session. 
-        Using cmd.load and mediate by PDB format
+        """convert enzy_htp.Structure into a pymol object in a pymol2.PyMOL() session. Performs 
+        operation without writing to disk.
         
         Returns:
             (pymol_obj_name, session) since the name is only valid in the session
             
         Note: pymol wont reset residue idx or chain names but will reset atom index from 1"""
 
-        # create temp PDB
         self.check_pymol2_installed()
-        pdb_str = PDBParser().get_file_str(stru, if_renumber=False)
-        temp_dir = eh_config["system.SCRATCH_DIR"]
-        temp_pdb_path = fs.get_valid_temp_name(f"{temp_dir}/temp_pymol_interface.pdb")
-        fs.safe_mkdir(temp_dir)
-        with open(temp_pdb_path, "w") as f:
-            f.write(pdb_str)
-        # create pymol obj
-        pymol_obj_name = session.cmd.get_unused_name("enzy_htp_stru")
-        session.cmd.load(temp_pdb_path, pymol_obj_name)
+        
+        pdb_str:str = PDBParser().get_file_str(stru, if_renumber=False)
+        
+        pymol_obj_name:str = self.general_cmd(session, [('get_unused_name',)])[0] 
+        
+        self.general_cmd(session, [('read_pdb_str', pdb_str, pymol_obj_name)])
 
-        # clean up temp PDB
-        fs.clean_temp_file_n_dir([temp_dir, temp_pdb_path])
 
         return (pymol_obj_name, session)
 

--- a/test/_interface/test_pymol_interface.py
+++ b/test/_interface/test_pymol_interface.py
@@ -23,7 +23,7 @@ def test_load_enzy_htp_stru():
     pi = interface.pymol
     test_session = pi.new_session()
     pymol_obj_name, session = pi.load_enzy_htp_stru(test_session, test_stru)
-    assert pymol_obj_name == "enzy_htp_stru01"
+    assert pymol_obj_name == "tmp01"
     assert pymol_obj_name in session.cmd.get_object_list()
     assert test_stru.chain_names == session.cmd.get_chains(pymol_obj_name)
     assert len(session.cmd.get_model(pymol_obj_name).get_residues()) == test_stru.num_residues
@@ -39,7 +39,7 @@ def test_load_enzy_htp_stru_not_start_from_one():
     pi = interface.pymol
     test_session = pi.new_session()
     pymol_obj_name, session = pi.load_enzy_htp_stru(test_session, test_stru)
-    assert pymol_obj_name == "enzy_htp_stru01"
+    assert pymol_obj_name == "tmp01"
     assert pymol_obj_name in session.cmd.get_object_list()
     assert test_stru.chain_names == session.cmd.get_chains(pymol_obj_name)
     assert len(session.cmd.get_model(pymol_obj_name).get_residues()) == test_stru.num_residues


### PR DESCRIPTION
Quick PR. It turns out that you can actually just use the pymol API function `read_pdbstr()` to load a `Structure()` without having to do file I/O. Updated it within `enzy_htp._interface.pymol_interface.load_enzy_htp_stru()`. Should be a quick PR!