### PR TITLE
`StructureTranslator` PR

### DIFF
--- a/enzy_htp/structure/__init__.py
+++ b/enzy_htp/structure/__init__.py
@@ -21,6 +21,7 @@ from .modified_residue import ModifiedResidue, residue_to_modified_residue
 from .noncanonical_base import NonCanonicalBase
 from .chain import Chain
 from .structure import Structure
+from .structure_translator import (translate_structure, TranslatorBase)
 from .structure_ensemble import StructureEnsemble
 from .structure_io import PDBParser, Mol2Parser, PrepinParser
 

--- a/enzy_htp/structure/structure_translator/__init__.py
+++ b/enzy_htp/structure/structure_translator/__init__.py
@@ -1,0 +1,13 @@
+"""The structure.structure_translator sub-module revolves around renmaing Atom()'s and Residue()'s 
+to a given standard. EnzyHTP assumes the AmberMD naming scheme as a standard but 
+the TranslatorBase() represents a template for how to convert to and from AmberMD's naming for an 
+arbitrary naming scheme. Users should access this functionality through the translate_structure() 
+free function.
+
+Author: Chris Jurich
+Date: 2024-02-11
+"""
+
+from .translator_base import TranslatorBase
+
+from .api import translate_structure

--- a/enzy_htp/structure/structure_translator/api.py
+++ b/enzy_htp/structure/structure_translator/api.py
@@ -20,7 +20,7 @@ from .translator_base import TranslatorBase
 from .rosetta_translator import RosettaTranslator
 
 
-def translate_structure(stru:Structure, start_naming:str=None, end_naming:str=None) -> Union[None, Structure]:
+def translate_structure(stru:Structure, start_naming:str=None, end_naming:str=None) -> None:
     """Translates names of the supplied Structure()'s Residue() and Atom() objects to EnzyHTP standard or 
     a supported naming convention. Exactly one of start_naming or end_naming scheme must be supplied. It is assumed that
     the other, blank parameter is EnzyHTP standard/AmberMD. end_naming should be left blank if a Structure() is to be 
@@ -34,7 +34,7 @@ def translate_structure(stru:Structure, start_naming:str=None, end_naming:str=No
         end_naming:  The ending naming scheme as a str().
 
     Returns:
-        Nothing or a renamed Structure(), depending on usage of inplace. 
+        Nothing.
     """
     
     err_msg = str()

--- a/enzy_htp/structure/structure_translator/api.py
+++ b/enzy_htp/structure/structure_translator/api.py
@@ -1,0 +1,70 @@
+"""Free function for translating the names of a Structure()'s Residue() and Atom() objects. Should be called
+by users, supports the conversion of names between EnzyHTP standard (AmberMD) and:
+
+    + Rosetta
+
+as well as converting back to EnzyHTP standard. All functionality is handled through `translate_structure()`.
+
+Author: Chris Jurich <chris.jurich@vanderbilt.edu>
+Date: 2024-02-11
+"""
+from typing import Dict, Union
+
+from enzy_htp.core import _LOGGER
+
+from ..atom import Atom
+from ..residue import Residue
+from ..structure import Structure
+
+from .translator_base import TranslatorBase
+from .rosetta_translator import RosettaTranslator
+
+
+def translate_structure(stru:Structure, start_naming:str=None, end_naming:str=None) -> Union[None, Structure]:
+    """Translates names of the supplied Structure()'s Residue() and Atom() objects to EnzyHTP standard or 
+    a supported naming convention. Exactly one of start_naming or end_naming scheme must be supplied. It is assumed that
+    the other, blank parameter is EnzyHTP standard/AmberMD. end_naming should be left blank if a Structure() is to be 
+    converted to EnzyHTP standard and start_naming should be left blank if a Structure() is already in EnzyHTP standard naming.
+    Function performs basic checks on supplied naming parameters and will error if they are invalid. Naming is always done
+    in place.
+
+    Args:
+        stru: The Structure() to rename.
+        start_naming: The starting naming scheme as a str().
+        end_naming:  The ending naming scheme as a str().
+
+    Returns:
+        Nothing or a renamed Structure(), depending on usage of inplace. 
+    """
+    
+    err_msg = str()
+    if start_naming is None and end_naming is None:
+        err_msg = f"To translate a Structure() you must supply either start_naming or end_naming! Both are empty!"
+
+    elif start_naming is not None and end_naming is not None:
+        err_msg = f"To translate a Structure() you must supply either start_naming or end_naming! Both have non-empty values!"
+    
+    else:
+        if start_naming:
+            translator = TRANSLATORS.get(start_naming, None)
+            if translator is None:
+                err_msg = f"The supplied start_naming scheme {start_naming} is not supported. Allowed values are {', '.join(TRANSLATORS.keys())}"
+            else:
+                translator.to_standard(stru)
+    
+        if end_naming:
+            translator = TRANSLATORS.get(end_naming, None)
+            if translator is None:
+                err_msg = f"The supplied end_naming scheme {end_naming} is not supported. Allowed values are {', '.join(TRANSLATORS.keys())}"
+            else:
+                translator.from_standard(stru)
+    
+    if err_msg:
+        _LOGGER.error(err_msg)
+        raise ValueError(err_msg) 
+
+
+TRANSLATORS:Dict[str, TranslatorBase] = {
+    'rosetta': RosettaTranslator()
+}
+"""Mapper that holds instances of all the supported Translators."""

--- a/enzy_htp/structure/structure_translator/rosetta_translator.py
+++ b/enzy_htp/structure/structure_translator/rosetta_translator.py
@@ -17,8 +17,7 @@ from .translator_base import TranslatorBase
 
 
 class RosettaTranslator(TranslatorBase):
-    """
-    """
+    """Instantiation of TranslatorBase() for the Rosetta molecular modellig suite. """
 
     def naming_style(self) -> str:
         """This is the Rosetta naming scheme."""
@@ -29,7 +28,6 @@ class RosettaTranslator(TranslatorBase):
     def to_standard(self, res:Residue) -> None:
         """Special overloaded of to_standard() that addresses funky histidine 3 letter naming."""
 
-        
         if res.name == 'HIS':
             atom_names = [aa.name for aa in res.atoms]
 
@@ -52,6 +50,7 @@ class RosettaTranslator(TranslatorBase):
 
 
     def init_mappings(self) -> None:
+        """Registers mappings for Rosetta to/from AmberMD. Most changes relate to Hydrogens."""
         self.register_mapping('ALA', ['HB1', 'HB2', 'HB3', 'H1', 'H2', 'H3'], 
                                 'ALA', ['1HB', '2HB', '3HB', '1H', '2H', '3H'])
         self.register_mapping('ARG', ['HB3', 'HB2', 'HG3', 'HG2', 'HD3', 'HD2', 'HH11', 'HH12', 'HH21', 'HH22', 'H1', 'H2', 'H3'],

--- a/enzy_htp/structure/structure_translator/rosetta_translator.py
+++ b/enzy_htp/structure/structure_translator/rosetta_translator.py
@@ -1,0 +1,95 @@
+
+from plum import dispatch
+
+from ..atom import Atom
+from ..residue import Residue
+from ..structure import Structure
+
+
+from .translator_base import TranslatorBase
+
+
+
+
+class RosettaTranslator(TranslatorBase):
+
+
+
+
+    def naming_style(self) -> str:
+        return "rosetta"
+
+
+    @dispatch
+    def to_standard(self, res:Residue) -> None:
+
+        
+        if res.name == 'HIS':
+            atom_names = [aa.name for aa in res.atoms]
+
+            has_delta:bool = 'HD1' in atom_names
+            has_eps:bool = 'HE2' in atom_names
+
+            new_name:str = None
+
+            if has_delta and has_eps:
+                new_name = 'HIP'
+            elif has_delta:
+                new_name = 'HID'
+            elif has_eps:
+                new_name = 'HIE'
+            else:
+                raise ValueError()
+            res.name = new_name
+        else:
+            super().to_standard(res)    
+
+
+    def init_mappings(self) -> None:
+        self.register_mapping('ALA', ['HB1', 'HB2', 'HB3', 'H1', 'H2', 'H3'], 
+                                'ALA', ['1HB', '2HB', '3HB', '1H', '2H', '3H'])
+        self.register_mapping('ARG', ['HB3', 'HB2', 'HG3', 'HG2', 'HD3', 'HD2', 'HH11', 'HH12', 'HH21', 'HH22', 'H1', 'H2', 'H3'],
+                                'ARG', ['1HB', '2HB', '1HG', '2HG', '1HD', '2HD', '1HH1', '2HH1', '1HH2', '2HH2', '1H', '2H', '3H'])
+        self.register_mapping('ASN', ['HB3', 'HB2', 'HD21', 'HD22', 'H1', 'H2', 'H3'],
+                                'ASN', ['1HB', '2HB', '1HD2', '2HD2', '1H', '2H', '3H'])
+        self.register_mapping('ASP', ['HB3', 'HB2', 'H1', 'H2', 'H3'], 
+                                'ASP', ['1HB', '2HB', '1H', '2H', '3H'])
+        self.register_mapping('CYS', ['HB3', 'HB2', 'H1', 'H2', 'H3'],
+                                'CYS', ['1HB', '2HB', '1H', '2H', '3H'])
+        self.register_mapping('GLN', ['HB3', 'HB2', 'HG3', 'HG2', 'HE21', 'HE22', 'H1', 'H2', 'H3'], 
+                                'GLN', ['1HB', '2HB', '1HG', '2HG', '1HE2', '2HE2', '1H', '2H', '3H'])
+        self.register_mapping('GLU', ['HB3', 'HB2', 'HG3', 'HG2', 'H1', 'H2', 'H3'], 
+                                'GLU', ['1HB', '2HB', '1HG', '2HG', '1H', '2H', '3H'])
+        self.register_mapping('GLY', ['HA3', 'HA2', 'H1', 'H2', 'H3'], 
+                                'GLY', ['1HA', '2HA', '1H', '2H', '3H'])
+      
+        self.register_mapping('HID', ['HB3', 'HB2', 'H1', 'H2', 'H3'], 
+                                'HIS', ['1HB', '2HB', '1H', '2H', '3H'])
+        self.register_mapping('HIE', ['HB3', 'HB2', 'H1', 'H2', 'H3'], 
+                                'HIS', ['1HB', '2HB', '1H', '2H', '3H'])
+        self.register_mapping('HIP', ['HB3', 'HB2', 'H1', 'H2', 'H3'], 
+                                'HIS', ['1HB', '2HB', '1H', '2H', '3H'])
+
+        self.register_mapping('ILE', ['HG13', 'HG12', 'HG21', 'HG22', 'HG23', 'HD11', 'HD12', 'HD13', 'H1', 'H2', 'H3'], 
+                                'ILE', ['1HG1', '2HG1', '1HG2', '2HG2', '3HG2', '1HD1', '2HD1', '3HD1', '1H', '2H', '3H'])
+        self.register_mapping('LEU', ['HB3', 'HB2', 'HD11', 'HD12', 'HD13', 'HD21', 'HD22', 'HD23', 'H1', 'H2', 'H3'], 
+                                'LEU', ['1HB', '2HB', '1HD1', '2HD1', '3HD1', '1HD2', '2HD2', '3HD2', '1H', '2H', '3H'])
+        self.register_mapping('LYS', ['HB3', 'HB2', 'HG3', 'HG2', 'HD3', 'HD2', 'HE3', 'HE2', 'HZ1', 'HZ2', 'HZ3', 'H1', 'H2', 'H3'], 
+                                'LYS', ['1HB', '2HB', '1HG', '2HG', '1HD', '2HD', '1HE', '2HE', '1HZ', '2HZ', '3HZ', '1H', '2H', '3H'])
+        self.register_mapping('MET', ['HB3', 'HB2', 'HG3', 'HG2', 'HE1', 'HE2', 'HE3', 'H1', 'H2', 'H3'], 
+                                'MET', ['1HB', '2HB', '1HG', '2HG', '1HE', '2HE', '3HE', '1H', '2H', '3H'])
+        self.register_mapping('PHE', ['HB3', 'HB2', 'H1', 'H2', 'H3'], 
+                                'PHE', ['1HB', '2HB', '1H', '2H', '3H'])
+        self.register_mapping('PRO', ['HB3', 'HB2', 'HG3', 'HG2', 'HD3', 'HD2', 'H1', 'H2', 'H3'], 
+                                'PRO', ['1HB', '2HB', '1HG', '2HG', '1HD', '2HD', '1H', '2H', '3H'])
+        self.register_mapping('SER', ['HB3', 'HB2', 'H1', 'H2', 'H3'], 
+                                'SER', ['1HB', '2HB', '1H', '2H', '3H'])
+        self.register_mapping('THR', ['HG21', 'HG22', 'HG23', 'H1', 'H2', 'H3'], 
+                                'THR', ['1HG2', '2HG2', '3HG2', '1H', '2H', '3H'])
+        self.register_mapping('TRP', ['HB3', 'HB2', 'H1', 'H2', 'H3'], 
+                                'TRP', ['1HB', '2HB', '1H', '2H', '3H'])
+        self.register_mapping('TYR', ['HB3', 'HB2', 'H1', 'H2', 'H3'], 
+                                'TYR', ['1HB', '2HB', '1H', '2H', '3H'])
+        self.register_mapping('VAL', ['HG11', 'HG12', 'HG13', 'HG21', 'HG22', 'HG23', 'H1', 'H2', 'H3'], 
+                                'VAL', ['1HG1', '2HG1', '3HG1', '1HG2', '2HG2', '3HG2', '1H', '2H', '3H'])
+

--- a/enzy_htp/structure/structure_translator/rosetta_translator.py
+++ b/enzy_htp/structure/structure_translator/rosetta_translator.py
@@ -1,3 +1,10 @@
+"""Instantiation of TranslatorBase for the Rosetta molecular modelling suite. This class 
+enables support for translation of canonical amino acid names to and from the standard
+AmberMD scheme in EnzyHTP.
+
+Author: Chris Jurich <chris.jurich@vanderbilt.edu>
+Date: 2024-05-27
+"""
 
 from plum import dispatch
 
@@ -9,19 +16,18 @@ from ..structure import Structure
 from .translator_base import TranslatorBase
 
 
-
-
 class RosettaTranslator(TranslatorBase):
-
-
-
+    """
+    """
 
     def naming_style(self) -> str:
+        """This is the Rosetta naming scheme."""
         return "rosetta"
 
 
     @dispatch
     def to_standard(self, res:Residue) -> None:
+        """Special overloaded of to_standard() that addresses funky histidine 3 letter naming."""
 
         
         if res.name == 'HIS':

--- a/enzy_htp/structure/structure_translator/rosetta_translator.py
+++ b/enzy_htp/structure/structure_translator/rosetta_translator.py
@@ -17,7 +17,7 @@ from .translator_base import TranslatorBase
 
 
 class RosettaTranslator(TranslatorBase):
-    """Instantiation of TranslatorBase() for the Rosetta molecular modellig suite. """
+    """Specialization of TranslatorBase() for the Rosetta molecular modellig suite."""
 
     def naming_style(self) -> str:
         """This is the Rosetta naming scheme."""

--- a/enzy_htp/structure/structure_translator/translator_base.py
+++ b/enzy_htp/structure/structure_translator/translator_base.py
@@ -1,6 +1,14 @@
+"""The TranslatorBase describes the API for supporting the translation of a Structure's canonical amino acid Residue and Atom names. 
+In this scheme, AmberMD naming represents the standard naming scheme. Mapping is executed in the TranslatorBase.init_mappings() function,
+which will call on static, pre-defined calls to TranslatorBase.register_mapping() function. For more information and examples, see 
+the rosetta version in enzy_htp/structure/translate_structure/rosetta_translator.py
+
+Author: Chris Jurich <chris.jurich@vanderbilt.edu>
+Date: 2024-05-27
+"""
+
 from typing import Dict, Tuple, List
 from abc import ABC, abstractmethod
-
 
 from plum import dispatch
 
@@ -12,8 +20,21 @@ from ..structure import Structure
 
 
 class TranslatorBase(ABC):
+    """Defines the API for translating to/from a given naming scheme. There must be one for each
+    naming scheme, the standard naming scheme is AmberMD and translation is primarily targeted at 
+    canonical amino acids. All translation occurs through overloaded versions of the to_standard()
+    and from_standard() methods.
 
+    Attributes:
+        TO_STANDARD: A dict() with (key, value) pairs of (translated_resname, standard_res_name) and 
+            ((translated_resname, translated_atom_name), (standard_resname, standard_atom_name)) for each 
+            residue code and atom name, respectively.
+        FROM_STANDARD: A dict() with (key, value) pairs of (standard_res_name, translated_resname) and 
+            ((standard_resname, standard_atom_name), (translated_resname, translated_atom_name)) for each
+            residue code and atom name, respectively.
+    """
     def __init__(self):
+        """Simplistic constructor that initializes variables then calls child-instantiated init_mappings() method."""
         self.TO_STANDARD = dict()
         self.FROM_STANDARD = dict()
         self.init_mappings()
@@ -23,9 +44,23 @@ class TranslatorBase(ABC):
                         s_rname:str,
                         s_atoms:List[str],
                         t_rname:str,
-                        t_atoms:List[str]):
+                        t_atoms:List[str]) -> None:
+        """Workhorse method where one defines how the same residue is described in multiple 
+        software packages. s_ prefix is for standard, t_ prefix is for translatred. Function works 
+        for only one Residue. Note that the number of Atom()'s must be the same and that
+        the supplied atom names in s_atoms and 
+        
+        Args:
+            s_rname: What is the 3-letter Residue name in AmberMD?
+            s_atoms: What are the atom names for the Residue in AmberMD?
+            t_rname: What is the 3-letter Residue name in the other naming scheme?
+            s_atoms: What are the atom names for the Residue in the other name scheme?
 
-        assert len(s_atoms) == len(t_atoms)
+        Returns:
+            Nothing.
+        """
+
+        assert len(s_atoms) == len(t_atoms) #TODO(CJ): use error logging here
 
         for s_aa, t_aa in zip(s_atoms, t_atoms):
             s_key:Tuple[str, str] = (s_rname, s_aa)
@@ -82,6 +117,7 @@ class TranslatorBase(ABC):
 
     @dispatch
     def from_standard(self, res:Residue) -> None:
+        
         value = self.FROM_STANDARD.get(res.name, None)
 
         if value is None:
@@ -103,9 +139,11 @@ class TranslatorBase(ABC):
 
     @abstractmethod
     def naming_style(self) -> str:
+        """What naming scheme is in use?"""
         pass
 
     @abstractmethod
     def init_mappings(self) -> None:
+        """Mappings are defined here through various calls to regiset_mapping()"""
         pass
 

--- a/enzy_htp/structure/structure_translator/translator_base.py
+++ b/enzy_htp/structure/structure_translator/translator_base.py
@@ -54,7 +54,7 @@ class TranslatorBase(ABC):
             s_rname: What is the 3-letter Residue name in AmberMD?
             s_atoms: What are the atom names for the Residue in AmberMD?
             t_rname: What is the 3-letter Residue name in the other naming scheme?
-            s_atoms: What are the atom names for the Residue in the other name scheme?
+            t_atoms: What are the atom names for the Residue in the other name scheme?
 
         Returns:
             Nothing.

--- a/enzy_htp/structure/structure_translator/translator_base.py
+++ b/enzy_htp/structure/structure_translator/translator_base.py
@@ -60,7 +60,13 @@ class TranslatorBase(ABC):
             Nothing.
         """
 
-        assert len(s_atoms) == len(t_atoms) #TODO(CJ): use error logging here
+        n_s_atoms:int = len(s_atoms)
+        n_t_atoms:int = len(t_atoms)
+        
+        if n_s_atoms != n_t_atoms:
+            err_msg = f"Error! Number of standard-named and translated atoms must be the same, but got {n_s_atoms} vs {n_t_atoms}"
+            _LOGGER.error(err_msg)
+            raise ValueError(err_msg)
 
         for s_aa, t_aa in zip(s_atoms, t_atoms):
             s_key:Tuple[str, str] = (s_rname, s_aa)

--- a/enzy_htp/structure/structure_translator/translator_base.py
+++ b/enzy_htp/structure/structure_translator/translator_base.py
@@ -1,0 +1,111 @@
+from typing import Dict, Tuple, List
+from abc import ABC, abstractmethod
+
+
+from plum import dispatch
+
+from enzy_htp.core import _LOGGER
+
+from ..atom import Atom
+from ..residue import Residue
+from ..structure import Structure
+
+
+class TranslatorBase(ABC):
+
+    def __init__(self):
+        self.TO_STANDARD = dict()
+        self.FROM_STANDARD = dict()
+        self.init_mappings()
+
+    
+    def register_mapping(self,
+                        s_rname:str,
+                        s_atoms:List[str],
+                        t_rname:str,
+                        t_atoms:List[str]):
+
+        assert len(s_atoms) == len(t_atoms)
+
+        for s_aa, t_aa in zip(s_atoms, t_atoms):
+            s_key:Tuple[str, str] = (s_rname, s_aa)
+            t_key:Tuple[str, str] = (t_rname, t_aa)
+            self.TO_STANDARD[t_key] = s_key
+            self.FROM_STANDARD[s_key] = t_key
+            self.TO_STANDARD[t_rname] = s_rname
+            self.FROM_STANDARD[s_rname] = t_rname
+    
+    @dispatch
+    def to_standard(self, stru:Structure) -> None:
+        for res in stru.residues:
+            if not res.is_canonical():
+                continue
+            
+            for atom in res.atoms:
+                self.to_standard(atom)
+
+            self.to_standard(res)
+
+    @dispatch
+    def to_standard(self, res:Residue) -> None:
+
+        value = self.TO_STANDARD.get(res.name, None)
+
+        if value is None:
+            return
+
+        res.name = value
+
+
+    @dispatch
+    def to_standard(self, atom:Atom) -> None:
+        
+        key = (atom.parent.name, atom.name)
+        value = self.TO_STANDARD.get(key, None)
+
+        if value is None:
+            return
+
+        atom.name = value[1]
+
+    @dispatch
+    def from_standard(self, stru:Structure) -> None:
+        for res in stru.residues:
+            if not res.is_canonical():
+                continue
+            
+            for atom in res.atoms:
+                self.from_standard(atom)
+
+            self.from_standard(res)
+
+
+    @dispatch
+    def from_standard(self, res:Residue) -> None:
+        value = self.FROM_STANDARD.get(res.name, None)
+
+        if value is None:
+            return
+
+        res.name = value
+
+    @dispatch
+    def from_standard(self, atom:Atom) -> None:
+        
+        key = (atom.parent.name, atom.name)
+        value = self.FROM_STANDARD.get(key, None)
+
+        if value is None:
+            return
+
+        atom.name = value[1]
+
+
+    @abstractmethod
+    def naming_style(self) -> str:
+        pass
+
+    @abstractmethod
+    def init_mappings(self) -> None:
+        pass
+

--- a/test/structure/structure_translator/test_translate_structure.py
+++ b/test/structure/structure_translator/test_translate_structure.py
@@ -1,0 +1,51 @@
+"""Testing correctness for the transate_structure() function found in enzy_htp.structure.structure_translator.api.py
+
+Author: Chris Jurich <chris.jurich@vanderbilt.edu>
+Date: 2024-05-27
+"""
+import pytest
+import os
+
+from enzy_htp.structure import (
+    translate_structure,
+    PDBParser,
+    Structure
+)
+
+CURR_FILE = os.path.abspath(__file__)
+CURR_DIR = os.path.dirname(CURR_FILE)
+DATA_DIR = f"{CURR_DIR}/../data/"
+
+def test_translate_structure_bad_naming_inputs() -> None:
+    """Making sure translate_structure() errors for unsupported naming schemes."""
+    val_error = None
+    with pytest.raises(ValueError) as val_error:        
+        translate_structure(None)
+   
+    assert val_error is not None
+
+    val_error = None
+    with pytest.raises(ValueError) as val_error:        
+        translate_structure(None, start_naming="not_rosetta")
+   
+    assert val_error is not None
+    
+    val_error = None
+    
+    with pytest.raises(ValueError) as val_error:        
+        translate_structure(None, end_naming="not_rosetta")
+
+    assert val_error is not None
+
+def test_translate_structure_correct_result() -> None:
+    """Making sure the desired changes are made when using the translate_structure() function."""
+    parser = PDBParser()
+    stru:Structure = parser.get_structure(f"{DATA_DIR}/1Q4T_peptide_protonated.pdb")
+    
+    assert stru.residues[11].name == 'HID'
+    
+    translate_structure(stru, end_naming='rosetta')
+    assert stru.residues[11].name == 'HIS'
+    
+    translate_structure(stru, start_naming='rosetta')
+    assert stru.residues[11].name == 'HID'


### PR DESCRIPTION
Creating infrastructure to rename atoms and residues between different software packages such as AmberMD, Rosetta, etc. Very necessary to reduce errors. All functionality is accessed through the `translate_structure()` api in `enzy_htp/structure/structure_translator/api.py`. Note that the code only works for canonical amino acids and does not work for ligands, NCAAs or other different types of chemical entities. 