### PR TITLE
Shaoqz/hotfix addpdb

### DIFF
--- a/enzy_htp/_interface/amber_interface.py
+++ b/enzy_htp/_interface/amber_interface.py
@@ -1869,7 +1869,16 @@ class AmberInterface(BaseInterface):
         cmd_args = f"-i {in_prmtop} -p {ref_pdb} -o {out_path}"
         if guess:
             cmd_args = f"{cmd_args} -guess"
-        self.env_manager_.run_command("add_pdb", cmd_args)
+
+        result = self.env_manager_.run_command("add_pdb", cmd_args)
+
+        # error check. NOTE: add_pdb will not return error code when failed. The only sign is the output prmtop is empty.
+        if not fs.is_path_exist(out_path) or os.path.getsize(out_path) == 0:
+            # decode error information from stdout and stderr
+            error_info = f"stdout: \n{result.stdout.decode() if isinstance(result.stdout, bytes) else str(result.stdout)}\n"
+            error_info += f"stderr: \n{result.stderr.decode() if isinstance(result.stderr, bytes) else str(result.stderr)}\n"
+            _LOGGER.error(f"Empty output .prmtop found. add_pdb seems failed.\n {error_info}.")
+            raise AddPDBError("add_pdb failed. Please check the input files.")
 
     def clean_up_add_pdb_info(self, in_prmtop: str, out_path: str):
         """remove add_pdb info in prmtop"""

--- a/enzy_htp/_interface/amber_interface.py
+++ b/enzy_htp/_interface/amber_interface.py
@@ -51,6 +51,7 @@ from enzy_htp.structure.structure_constraint import (
     CartesianFreeze,
     merge_cartesian_freeze)
 from enzy_htp.structure.structure_region import create_region_from_residues
+import enzy_htp.structure.structure_operation as stru_oper
 from enzy_htp.structure import StruSelection
 from enzy_htp.structure import (
     Structure,
@@ -217,6 +218,13 @@ class AmberParameterizer(MolDynParameterizer):
         temp_prmtop = fs.get_valid_temp_name(f"{self.parameterizer_temp_dir}/amber_parm_missing_pdb_info.prmtop")
         temp_ref_pdb = fs.get_valid_temp_name(f"{self.parameterizer_temp_dir}/amber_parm_ref_pdb.pdb")
         fs.safe_mkdir(self.parameterizer_temp_dir)
+
+        # 0. san check
+        if stru.contain_solvent():
+            _LOGGER.warning("The input structure contains solvent. tleap will ignore them and re-solvate the system. "
+                            "If you want to keep original solvent, please given them a different name other than WAT or HOH.")
+            stru = copy.deepcopy(stru)
+            stru_oper.remove_solvent(stru)
 
         # 1. check stru diversity
         diversity = stru.chemical_diversity


### PR DESCRIPTION
This pull request fix a bug caused by having solvent in the input structure of AmberParameterizer. The most significant changes include a new solvent check and removal step before parameterization, and robust error detection for the `add_pdb` process to prevent silent failures.

**Structure preparation and solvent handling:**

* Added a check to detect if the input structure contains solvent. If solvent is present, a warning is logged, and the solvent is removed using `stru_oper.remove_solvent` before proceeding, ensuring compatibility with Amber's solvation protocol.

**Error handling improvements:**

* Enhanced the `run_add_pdb` method to verify the existence and non-emptiness of the output `.prmtop` file. If the file is missing or empty, detailed error information from stdout and stderr is logged, and a custom `AddPDBError` is raised to prevent silent failures.